### PR TITLE
rbx-19 isn't supported anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ rvm:
   - jruby-19mode
   - jruby-head
   - rbx-2
-  - rbx-19mode
 
 matrix:
   allow_failures:
@@ -19,4 +18,3 @@ matrix:
     - rvm: jruby-19mode
     - rvm: jruby-head
     - rvm: rbx-2
-    - rvm: rbx-19mode


### PR DESCRIPTION
The Rubinius team is really only concerned with `rbx-2` and up.
